### PR TITLE
fix: Refactor plugin template to use newer API's

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,13 +1,26 @@
 ---
-direction: Horizontal
-parts:
+template:
+  direction: Horizontal
+  parts:
+    - direction: Vertical
+      borderless: true
+      split_size:
+        Fixed: 1
+      run:
+        plugin:
+          location: "zellij:tab-bar"
+    - direction: Vertical
+      body: true
+    - direction: Vertical
+      run:
+        plugin:
+          location: "file:target/wasm32-wasi/debug/{{project-name}}.wasm"
+    - direction: Vertical
+      borderless: true
+      split_size:
+        Fixed: 2
+      run:
+        plugin:
+          location: "zellij:status-bar"
+tabs:
   - direction: Vertical
-    split_size:
-      Fixed: 1
-    plugin: tab-bar
-  - direction: Vertical
-    plugin: target/wasm32-wasi/debug/{{project-name}}.wasm
-  - direction: Vertical
-    split_size:
-      Fixed: 2
-    plugin: status-bar


### PR DESCRIPTION
This updates the plugin template to use the newer API introduced in this [PR](https://github.com/zellij-org/zellij/pull/660).